### PR TITLE
fix: integration with collaboration plugin

### DIFF
--- a/packages/plugin-split-editing/src/index.ts
+++ b/packages/plugin-split-editing/src/index.ts
@@ -106,8 +106,7 @@ export const splitEditingProsePlugin = $prose((ctx) => {
 
       editorView.dispatch = (tr) => {
         editorView.updateState(editorView.state.apply(tr))
-
-        if (tr.getMeta('addToHistory') != false && tr.docChanged) {
+        if ((tr.getMeta('addToHistory') != false || tr.getMeta('y-sync$')) && tr.docChanged) {
           const editor = ctx.get(editorCtx)
           const content = editor.action(getMarkdown())
           onEditorInput(content)


### PR DESCRIPTION
Hello,
I noticed that `plugin-split-editing` is not compatible with `@milkdown/plugin-collab` and `y-sync`.
The reason why is that you filter out some transactions coming from `editorView.dispatch`, and that leaves the ones coming from y-sync out.
With the proposed fix, it now works well.
