### PR TITLE
fix: cannot read properties of undefined

### DIFF
--- a/packages/plugin-split-editing/package.json
+++ b/packages/plugin-split-editing/package.json
@@ -27,8 +27,9 @@
   "devDependencies": {
     "@milkdown/core": "^7.4.0",
     "@milkdown/prose": "^7.4.0",
+    "style-mod": "^4.1.0",
     "tsup": "^8.2.4",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
   },
   "dependencies": {
     "@codemirror/commands": "^6.6.0",

--- a/packages/plugin-split-editing/src/codemirror.ts
+++ b/packages/plugin-split-editing/src/codemirror.ts
@@ -22,6 +22,7 @@ import {
   rectangularSelection,
 } from '@codemirror/view'
 import { $ctx } from '@milkdown/utils'
+import { StyleModule } from 'style-mod'
 import { Options } from '.'
 
 const basicSetup: Extension = [
@@ -72,9 +73,13 @@ export class CodemirrorEditor {
       extensions: [
         basicSetup,
         markdown(),
-        EditorView.styleModule.of({
-          getRules: () => '.cm-editor{height:100%}',
-        }),
+        EditorView.styleModule.of(
+          new StyleModule({
+            '.cm-editor': {
+              height: '100%',
+            },
+          }),
+        ),
         EditorView.lineWrapping,
         updateListener,
         ...extensions,


### PR DESCRIPTION
Hello again,
There is another small bug that gives an error `Cannot read properties of undefined (reading 'length')`.
I contacted the author of CodeMirror thinking that the bug was with the lib `style-mod`, but in fact, it is just because you are not using the StyleModule API correctly, as [he told me](https://github.com/marijnh/style-mod/pull/13#issuecomment-2271171342).

Here is the fix.
I tested and it works well.
Could you please do another minor release too ? So i could have a nice dependency tree in my project, with the fix coming from npm.
Thank you